### PR TITLE
Exclude binary assets in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,24 @@ go.work.sum
 
 # env file
 .env
+
+# Binary assets
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.ico
+*.pdf
+*.zip
+*.tar
+*.tar.gz
+*.rar
+*.7z
+*.mp3
+*.mp4
+*.mov
+*.avi
+*.wav
+*.flac
+


### PR DESCRIPTION
## Summary
- extend `.gitignore` with common binary asset patterns so binary files are not added to the repository

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68404f53bf8883259ba20a42de48fc4d